### PR TITLE
Reduce energy usage

### DIFF
--- a/SwiftUTCMenuClock/StatusMenuController.swift
+++ b/SwiftUTCMenuClock/StatusMenuController.swift
@@ -23,23 +23,40 @@ class StatusMenuController: NSObject {
 		formatter.timeZone = TimeZone(identifier: "Etc/UTC")
 		formatter.dateFormat = "HH:mm zzz"
 		
-		// Set up a timer running every 0.03 seconds that gets the current time and formats it for the menu bar.
+		let calendar = Calendar.current
+		
+		// Set up a timer running every 0.01 seconds that gets the current time and formats it, if needed, for the menu bar.
 		// (Most other utilities like this one run a timer like this every 1.00 seconds, which is bad and wrong.)
-		Timer.scheduledTimer(withTimeInterval: 0.03, repeats: true) { _ in
+		Timer.scheduledTimer(withTimeInterval: 0.01, repeats: true) { _ in
 			let now = Date(timeIntervalSinceNow: 0)
 			
-			let dateString = formatter.string(from: now)
+			// Check the current millisecond to see if we actually need to update the time string.
+			let millisecond = calendar.component(.nanosecond, from: now) / 1000000
+			switch millisecond {
+			case 0...9:
+				// We've got a second on the second (approximately). We need to update the time.
+				// Format the current time into a human-readable string and set the title.
+				let timeString = formatter.string(from: now)
+				self.statusItem.attributedTitle = self.formatTimeString(string: timeString)
+			default:
+				// We don't need to format the time, so...do nothing.
+				break
+			}
 			
-			// To style this with monospaced digits (so other menu bar items don't wobble side-to-side with variable digit widths), we need to set up a NSMutableAttributedString. Joy!
-			let attributedString = NSMutableAttributedString(string: dateString)
-			// Set the range to cover the entire character range.
-			let range = NSRange(location: 0, length: dateString.count)
-			// And finally, apply the monospaced digit system font.
-			attributedString.addAttribute(.font, value: NSFont.monospacedDigitSystemFont(ofSize: 14, weight: .regular), range: range)
 			
-			// And it's done! Set the title for the menu bar item.
-			self.statusItem.attributedTitle = attributedString
 		}
+	}
+	
+	private func formatTimeString(string: String) -> NSMutableAttributedString {
+		// Set up an attributed string.
+		let attributedString = NSMutableAttributedString(string: string)
+		// Set the range to cover the entire character range.
+		let range = NSRange(location: 0, length: string.count)
+		// Apply the monospaced digit system font.
+		attributedString.addAttribute(.font, value: NSFont.monospacedDigitSystemFont(ofSize: 14, weight: .regular), range: range)
+		
+		// We're done here; return the attributed string.
+		return attributedString
 	}
 	
 	@IBAction func quitClicked(_ sender: Any) {

--- a/SwiftUTCMenuClock/StatusMenuController.swift
+++ b/SwiftUTCMenuClock/StatusMenuController.swift
@@ -34,7 +34,6 @@ class StatusMenuController: NSObject {
 			let centisecond = calendar.component(.nanosecond, from: now) / 10000000
 			switch centisecond {
 			case 0:
-				NSLog("Updating time")
 				// We've got a second on the second (approximately). We need to update the time.
 				// Format the current time into a human-readable string and set the title.
 				let timeString = formatter.string(from: now)

--- a/SwiftUTCMenuClock/StatusMenuController.swift
+++ b/SwiftUTCMenuClock/StatusMenuController.swift
@@ -31,9 +31,10 @@ class StatusMenuController: NSObject {
 			let now = Date(timeIntervalSinceNow: 0)
 			
 			// Check the current millisecond to see if we actually need to update the time string.
-			let millisecond = calendar.component(.nanosecond, from: now) / 1000000
-			switch millisecond {
-			case 0...9:
+			let centisecond = calendar.component(.nanosecond, from: now) / 10000000
+			switch centisecond {
+			case 0:
+				NSLog("Updating time")
 				// We've got a second on the second (approximately). We need to update the time.
 				// Format the current time into a human-readable string and set the title.
 				let timeString = formatter.string(from: now)


### PR DESCRIPTION
Fixes issue #1 by only updating the time string when it *actually* needs to be updated.

It checks the current centisecond every centisecond, and if it’s 0, we’ve approximately got a second on the second and only then do we need to update the time. (It’s unnecessary to be more precise than a centisecond between current display technology and what the human eye can even process.)

So because of this change, where the formatter code used to run about 30 times a second (!) it now runs only once. `DateFormatter` is expensive, and after making this change energy usage has decreased…a lot, so much so that the menu clock is no longer listed in Activity Monitor for me.